### PR TITLE
Corrected ports in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ yarn install
 yarn start
 ```
 
-Front should be running in ports 4000 (front) and 4001 (back)
+The frontend should be running on port 3000, and the backend on port 4001.
 
 # Configuring students
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ yarn install
 yarn start
 ```
 
-Front should be running in ports 5000 (front) and 5001 (back)
+Front should be running in ports 4000 (front) and 4001 (back)
 
 # Configuring students
 


### PR DESCRIPTION
The README currently states the project to run on ports 5000 and 5001. However, the code runs on ports 3000 and 4001:

Notably, despite the following CORS configuration, the front end is only accessible on 3000.
```js
const corsOptions = {
  origin: [
    "http://localhost:4000",
    "https://john-guerra.static.observableusercontent.com",
  ],
  // origin: "https://john-guerra.static.observableusercontent.com",
  optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
};
```

```json
  "proxy": "http://localhost:4001"
```