### PR TITLE
fix: replace deprecated Collection.update() with updateOne()

### DIFF
--- a/db/myDB.js
+++ b/db/myDB.js
@@ -59,7 +59,7 @@ function setGrade(grade, cbk) {
     const date = grade.timestamp.toDateString();
 
     // If grade.timestamp exists we are updating
-    grades.update(
+    grades.updateOne(
       {
         name: grade.name,
         date: date,
@@ -67,11 +67,13 @@ function setGrade(grade, cbk) {
         course: grade.course,
       },
       {
-        date: date,
-        timestamp: grade.timestamp || grade.timestamp,
-        name: grade.name,
-        grade: grade.grade,
-        course: grade.course,
+        $set: {
+          date: date,
+          timestamp: grade.timestamp,
+          name: grade.name,
+          grade: grade.grade,
+          course: grade.course,
+        },
       },
       { upsert: true },
       function (res) {


### PR DESCRIPTION
myDB.js uses Collection.update(), which was deprecated in MongoDB Node.js driver v3 and fully removed in v4 and v5. The project currently uses "mongodb": "^3.5.2", so it works today, but a future upgrade to v4 or v5 would cause a silent runtime failure at the exact moment a grade is saved.

Replaced grades.update() with grades.updateOne() and wrapped the replacement document in a $set operator, which is required by the modern API.

updateOne() with $set and upsert has been valid since MongoDB driver v2.x. This change is fully backward compatible with the current v3 install and requires zero dependency changes. It also unblocks a future upgrade to v4 or v5 without any further edits to this function. No other files modified.